### PR TITLE
Link the State resource to the associated DataNode resource

### DIFF
--- a/WP2RDF/src/main/java/org/wikipathways/wp2rdf/converter/StateConverter.java
+++ b/WP2RDF/src/main/java/org/wikipathways/wp2rdf/converter/StateConverter.java
@@ -53,7 +53,10 @@ public class StateConverter {
 		stateRes.addLiteral(Gpml.COLOR, Utils.colorToHex(elem.getColor()));
 		stateRes.addLiteral(Gpml.HEIGHT, elem.getMHeight());
 		stateRes.addLiteral(Gpml.LINE_STYLE, elem.getLineStyle() != LineStyle.DASHED ? "Solid" : "Broken");
-		stateRes.addLiteral(Gpml.GRAPH_REF, elem.getGraphRef());
+		if (elem.getGraphRef() != null) {
+		    stateRes.addLiteral(Gpml.GRAPH_REF, elem.getGraphRef());
+		    stateRes.addLiteral(Gpml.STATE_OF, model.createResource(data.getPathwayRes().getURI() + "/DataNode/" + elem.getGraphRef());
+		}
 		stateRes.addLiteral(Gpml.TEXTLABEL, elem.getTextLabel());
 		stateRes.addLiteral(Gpml.REL_X, elem.getRelX());
 		stateRes.addLiteral(Gpml.REL_Y, elem.getRelY());

--- a/WP2RDF/src/main/java/org/wikipathways/wp2rdf/ontologies/Gpml.java
+++ b/WP2RDF/src/main/java/org/wikipathways/wp2rdf/ontologies/Gpml.java
@@ -247,6 +247,9 @@ public class Gpml {
     public static final Property SOURCE = m_model.createProperty( "http://vocabularies.wikipathways.org/gpml#source" );
     
     /** <p>The type of a State.</p> */
+    public static final Property STATE_OF = m_model.createProperty( "http://vocabularies.wikipathways.org/gpml#stateOf" );
+
+    /** <p>The type of a State.</p> */
     public static final Property STATE_TYPE = m_model.createProperty( "http://vocabularies.wikipathways.org/gpml#stateType" );
     
     /** <p>The style of a group.</p> */


### PR DESCRIPTION
This is at the GPMLRDF level. Currently, the GPML State only has a Literal `graphRef` which makes it harder to lookup the `DataNode` because the `graphRef` is only unique local the the GPML file, and an extra match is needed to check they are both in the same pathway:

```sparql
SELECT DISTINCT ?dataNodeLabel (SAMPLE(?uniprot_) AS ?uniprot) ?typeLabel WHERE {
  ?type a gpml:State ; gpml:graphRef/^gpml:graphId ?dataNode ;
        dcterms:isPartOf ?pathway ; gpml:textlabel ?typeLabel .
  ?dataNode dcterms:isPartOf ?pathway ; gpml:textlabel ?dataNodeLabel ;
    ^wp:isAbout/wp:bdbUniprot ?uniprot_ .
} ORDER BY ASC(?dataNodeLabel)
```

By adding the `ObjectProperty` we have a resource to resource triple.